### PR TITLE
Added a warning about docker build, and enabled admonitions in mkdocs

### DIFF
--- a/docs/setup/server.md
+++ b/docs/setup/server.md
@@ -43,6 +43,9 @@ npm run start:bundle
 
 ### With Docker
 
+!!! failure "Not Supported Currently"
+    Avoid using Docker build until further notice. The current build is faulty and will not build correctly. Instead, install using the terminal in the section "With Terminal". 
+
 Optionally if you want to use Docker:
 
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,5 +28,7 @@ theme:
     - navigation.indexes
     - navigation.top
 markdown_extensions:
+  - admonition
+  - pymdownx.details
   - pymdownx.highlight
   - pymdownx.superfences


### PR DESCRIPTION
Hi! I noticed that we have an [issue](https://github.com/fosscord/fosscord-server/issues/400) with Docker build for Fosscord-server. I think we should also mention it in the docs as well. 

I also enabled [Admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#admonitions), which is a neat feature in Mkdocs that allow adding warnings, notices to highlight important information for readers. 