### PR TITLE
Add info about python being called "python"

### DIFF
--- a/docs/server/setup.md
+++ b/docs/server/setup.md
@@ -21,6 +21,8 @@ This is the latest bleeding edge version of fosscord-server, which may have bugs
 - (Only on Linux) ``gcc`` and ``g++`` or alternatively on debian-based distros ``build-essential``
 - (Only on Windows) [Visual Studio](https://visualstudio.microsoft.com/) with the C++ package
 
+!!! info "Make sure python can be executed by just running `python`"
+
 #### Setup
 
 Open a shell/terminal and execute these commands:


### PR DESCRIPTION
Most people have it installed as ``python3`` or whatever, which confuses setup