### PR TITLE
Add Client documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 site/
 .DS_STORE
+./venv/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 site/
 .DS_STORE
-./venv/*
+venv/

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,15 @@
 # Frequently Asked Questions
 
+??? info "How do you use the Client?"
+
+    As described in [Clients](/setup/clients), the official client is not ready yet. You are free to use
+    a Fosscord compatible client to connect, but no support will be provided.
+
+??? info "I am getting the error 'Cannot GET /', how fix?"
+
+    If you see that error message, it means that your server is configured correctly. Hooray!
+    Unfortunately, our official client isn't done yet (see question above).
+
 ??? info "Voice/Video when?"
 
     Currently there is no voice or video support in any Fosscord instance.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,11 +5,6 @@
     As described in [Clients](/setup/clients), the official client is not ready yet. You are free to use
     a Fosscord compatible client to connect, but no support will be provided.
 
-??? info "I am getting the error 'Cannot GET /', how fix?"
-
-    If you see that error message, it means that your server is configured correctly. Hooray!
-    Unfortunately, our official client isn't done yet (see question above).
-
 ??? info "Voice/Video when?"
 
     Currently there is no voice or video support in any Fosscord instance.

--- a/docs/setup/clients/index.md
+++ b/docs/setup/clients/index.md
@@ -1,0 +1,77 @@
+# Clients
+
+!!! note "The Fosscord client is, at the time of writing this (March 17th, 2023), under heavy development and not ready to be used in production just yet."
+
+!!! note "Windows support is currently broken."
+
+The official Fosscord client is currently being developed at [this repository](https://github.com/fosscord/fosscord-client/tree/dev/bare-rewrite).
+
+## Dependencies
+
+- [Git](https://git-scm.com/)
+- [NodeJS](https://nodejs.org). Version 16+
+- [yarn](https://yarnpkg.com/) (preferred) or npm
+
+## Setup/Building
+
+In your terminal:
+
+```bash
+# Download Fosscord Client
+git clone https://github.com/fosscord/fosscord-client.git
+
+# Enter the cloned directory, switch branches to the one, which is actually being developed
+cd fosscord-client; git switch dev/bare-rewrite
+
+# Install dependencies
+yarn install
+```
+
+To start the client with Metro for development, run
+
+```bash
+yarn start
+```
+
+!!! note "Platform-specific development commands:"
+
+    For development for Android, run
+
+    ```bash
+    yarn android
+    ```
+
+    For development for iOS, run
+
+    ```bash
+    yarn ios
+    ```
+
+    For development for Windows, run
+
+    ```bash
+    yarn windows
+    ```
+
+To build static files for the web, run
+
+```bash
+yarn build:web
+```
+
+Files will be built to `web-build`
+
+## Contributing
+
+To contribute:
+
+- [Fork the repository](https://github.com/fosscord/fosscord-client/fork)
+- Run the building instructions.
+- Commit & Push.
+- Pull Request & Done!
+
+### What can I contribute?
+
+- "Core" features like settings, editing messages, dms, markdown rendering, etc. What do you think are basic features that you would want? Some of the GitHub Issues apply to this.
+- Implementing other things like voice/video is fine too, though
+- [This](https://github.com/fosscord/fosscord-client/issues/21) is a good starting point and lists all things that are still missing from the client.

--- a/docs/setup/clients/index.md
+++ b/docs/setup/clients/index.md
@@ -8,9 +8,9 @@ The official Fosscord client is currently being developed at [this repository](h
 
 ## Dependencies
 
-- [Git](https://git-scm.com/)
-- [NodeJS](https://nodejs.org). Version 16+
-- [yarn](https://yarnpkg.com/) (preferred) or npm
+-   [Git](https://git-scm.com/)
+-   [NodeJS](https://nodejs.org). Version 16+
+-   [yarn](https://yarnpkg.com/) (preferred) or npm
 
 ## Setup/Building
 
@@ -65,13 +65,13 @@ Files will be built to `web-build`
 
 To contribute:
 
-- [Fork the repository](https://github.com/fosscord/fosscord-client/fork)
-- Run the building instructions.
-- Commit & Push.
-- Pull Request & Done!
+-   [Fork the repository](https://github.com/fosscord/fosscord-client/fork)
+-   Run the building instructions.
+-   Commit & Push.
+-   Pull Request & Done!
 
 ### What can I contribute?
 
-- "Core" features like settings, editing messages, dms, markdown rendering, etc. What do you think are basic features that you would want? Some of the GitHub Issues apply to this.
-- Implementing other things like voice/video is fine too, though
-- [This](https://github.com/fosscord/fosscord-client/issues/21) is a good starting point and lists all things that are still missing from the client.
+-   "Core" features like settings, editing messages, dms, markdown rendering, etc. What do you think are basic features that you would want? Some of the GitHub Issues apply to this.
+-   Implementing other things like voice/video is fine too, though
+-   [This](https://github.com/fosscord/fosscord-client/issues/21) is a good starting point and lists all things that are still missing from the client.

--- a/docs/setup/clients/index.md
+++ b/docs/setup/clients/index.md
@@ -2,17 +2,37 @@
 
 !!! note "The Fosscord client is, at the time of writing this (March 17th, 2023), under heavy development and not ready to be used in production just yet."
 
-!!! note "Windows support is currently broken."
+!!! warning "Windows support is currently broken."
 
 The official Fosscord client is currently being developed at [this repository](https://github.com/fosscord/fosscord-client/tree/dev/bare-rewrite).
 
-## Dependencies
+## Official host
+
+We currently host the client at [https://app.fosscord.com](https://app.fosscord.com).
+You can use it to connect to our official instance by default,
+or you can use it to connect to your own by editing your local storage to include the `routeSettings` key with the below example content:
+```json
+{
+	"api":"https://staging.fosscord.com/api/v9",
+	"cdn":"https://cdn.staging.fosscord.com",
+	"gateway":"wss://gateway.staging.fosscord.com",
+	"invite":"https://staging.fosscord.com/invite",
+	"template":"https://staging.fosscord.com/template",
+	"gift":"https://staging.fosscord.com/gift",
+	"scheduledEvent":"https://staging.fosscord.com/events"
+}
+```
+
+Replace the above endpoints with your own. If your domain name is `https://whatever.notasite`, then you'll most likely want to enter
+`https://whatever.noasite/api/v9` for the API endpoint, etc.
+
+## Setup/Building
+
+### Dependencies
 
 -   [Git](https://git-scm.com/)
 -   [NodeJS](https://nodejs.org). Version 16+
 -   [yarn](https://yarnpkg.com/) (preferred) or npm
-
-## Setup/Building
 
 In your terminal:
 
@@ -53,7 +73,7 @@ yarn start
     yarn windows
     ```
 
-To build static files for the web, run
+To build static files for the web (i.e. when hosting it yourself), run
 
 ```bash
 yarn build:web
@@ -74,4 +94,4 @@ To contribute:
 
 -   "Core" features like settings, editing messages, dms, markdown rendering, etc. What do you think are basic features that you would want? Some of the GitHub Issues apply to this.
 -   Implementing other things like voice/video is fine too, though
--   [This](https://github.com/fosscord/fosscord-client/issues/21) is a good starting point and lists all things that are still missing from the client.
+-   [This](https://github.com/fosscord/fosscord-client/issues/21) is a good starting point and lists the core features that are still missing from the client.

--- a/docs/setup/server/migatingFromStaging.md
+++ b/docs/setup/server/migatingFromStaging.md
@@ -3,7 +3,7 @@
 'Staging' refers to [this branch](https://github.com/fosscord/fosscord-server/tree/staging) of fosscord-server,
 which is deprecated in favour of [the refactor branch](https://github.com/fosscord/fosscord-server/tree/maddy/refactor) (if this is a 404, its just become the main branch now).
 
-!!! warn "If you were using SQLite, you will be unable to migrate to the new version. SQLite is primarily for testing and development purposes, and it should not be used for production."
+!!! warning "If you were using SQLite, you will be unable to migrate to the new version. SQLite is primarily for testing and development purposes, and it should not be used for production."
 
 To migrate from Staging:
 


### PR DESCRIPTION
This PR adds client documentation at ./docs/setup/clients and ./faq.md. Documentation includes setup of the client, as well as where to start, if you'd like to contribute to the client project. Feedback from #60 has been integrated.